### PR TITLE
Remove device flag from run.sh

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,7 +4,6 @@ set -e
 
 cd /usr/src/wyoming-glados || { echo "Unable to cd into /usr/src/wyoming-glados"; exit 1; }
 
-DEVICE=${DEVICE:-cuda}
 STREAMING=${STREAMING:-true}
 DEBUG=${DEBUG:-false}
 
@@ -24,5 +23,4 @@ fi
 python __main__.py \
     --uri 'tcp://0.0.0.0:10201' \
     $DEBUG_FLAG \
-    $STREAMING_FLAG \
-    --device="$DEVICE"
+    $STREAMING_FLAG


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the use of the `DEVICE` environment variable and the related command-line argument in the run script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->