### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,7 @@
 ---
 name: Release
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Jonah-May-OSS/wyoming-glados/security/code-scanning/1](https://github.com/Jonah-May-OSS/wyoming-glados/security/code-scanning/1)

To fix this problem, the workflow should explicitly set the `permissions:` key at the workflow or job level to limit the default GITHUB_TOKEN's permissions to the minimum necessary. Since this is a release workflow that creates releases, uploads assets, and closes milestones, the minimal required permission is likely `contents: write` (to create and publish releases). If it needs to modify issues or pull requests, you might also add those, but based on the provided steps, only `contents: write` is necessary.

You can add the permission globally (at the top level, right after `name:` and before or after `on:`), or per job (inside the `release:` job definition). The most robust and maintainable way is to add this at the top level, so it applies to all jobs (and can later be overridden by any job if needed).

The change needed:
- Add the following block after `name: Release` (line 2):
  ```yaml
  permissions:
    contents: write
  ```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
