### PR TITLE
Stream PCM as synthesized and pipeline sentence synthesis

### DIFF
--- a/download.py
+++ b/download.py
@@ -78,12 +78,9 @@ def ensure_model_exists(download_dir: Path, base_url: str):
             "filename": "glados-new.pt",
             "md5": "d6945ffd96ee0619d0d49a581b5b83ad",
         },
-        {
-            "filename": "tacotron-trt.ts",
-            # Allow locally rebuilt TRT engines to persist across restarts:
-            # download only when absent, otherwise keep the local engine.
-            "md5": None,
-        },
+        # NOTE: tacotron-trt.ts is intentionally not downloaded anymore. The
+        # released file is a mislabeled copy of glados-new.pt (Tacotron never
+        # actually ran through TensorRT); TTSRunner deletes local copies.
         {
             "filename": "en_us_cmudict_ipa_forward.pt",
             "md5": "33887f7f579f010ce4463534306120b0",

--- a/server/handler.py
+++ b/server/handler.py
@@ -278,7 +278,9 @@ class GladosEventHandler(AsyncEventHandler):
             except Exception as err:
                 # Best-effort teardown: suppress unexpected drain errors during
                 # cancellation, but keep diagnostics for debugging.
-                _LOGGER.debug("Ignoring drain task error during cancellation", exc_info=err)
+                _LOGGER.debug(
+                    "Ignoring drain task error during cancellation", exc_info=err
+                )
             self._drain_task = None
         self._sentence_queue = None
 

--- a/server/handler.py
+++ b/server/handler.py
@@ -275,8 +275,10 @@ class GladosEventHandler(AsyncEventHandler):
             except asyncio.CancelledError:
                 # Expected when awaiting a task that we explicitly cancelled.
                 pass
-            except Exception:
-                pass
+            except Exception as err:
+                # Best-effort teardown: suppress unexpected drain errors during
+                # cancellation, but keep diagnostics for debugging.
+                _LOGGER.debug("Ignoring drain task error during cancellation", exc_info=err)
             self._drain_task = None
         self._sentence_queue = None
 

--- a/server/handler.py
+++ b/server/handler.py
@@ -1,6 +1,7 @@
 """Event handler implementation for Wyoming GLaDOS TTS events."""
 
 import argparse
+import asyncio
 import logging
 from typing import Any
 
@@ -47,6 +48,13 @@ class GladosEventHandler(AsyncEventHandler):
 
         self.audio_started = False
 
+        # Streaming pipeline state: sentences are synthesized ahead of time
+        # while the previous sentence's audio is still being written to the
+        # client. _sentence_queue holds (pcm_queue, pump_task) pairs in
+        # sentence order; _drain_task writes their audio to the client.
+        self._sentence_queue: asyncio.Queue[Any] | None = None
+        self._drain_task: asyncio.Task[None] | None = None
+
     async def handle_event(self, event: Event) -> bool:
         if Describe.is_type(event.type):
             await self.write_event(self.wyoming_info_event)
@@ -72,6 +80,7 @@ class GladosEventHandler(AsyncEventHandler):
                 self.sbd = SentenceBoundaryDetector()
                 self._synthesize = Synthesize(text="", voice=stream_start.voice)
                 self.audio_started = False
+                await self._start_pipeline()
                 _LOGGER.debug("Text stream started: voice=%s", stream_start.voice)
                 return True
             if SynthesizeChunk.is_type(event.type):
@@ -80,20 +89,17 @@ class GladosEventHandler(AsyncEventHandler):
 
                 for sentence in self.sbd.add_chunk(stream_chunk.text):
                     _LOGGER.debug("Synthesizing stream sentence: %s", sentence)
-
-                    self._synthesize.text = sentence
-
-                    # Handle the synthesis (e.g., convert text to PCM, send AudioChunks)
-
-                    await self._handle_synthesize(self._synthesize, send_stop=False)
+                    await self._enqueue_sentence(sentence)
                 return True
             if SynthesizeStop.is_type(event.type):
                 assert self._synthesize is not None
-                self._synthesize.text = self.sbd.finish()
-                if self._synthesize.text:
+                final_text = self.sbd.finish()
+                if final_text:
                     # Final audio chunk(s)
 
-                    await self._handle_synthesize(self._synthesize, send_stop=False)
+                    await self._enqueue_sentence(final_text)
+
+                await self._finish_pipeline()
 
                 if self.audio_started:
                     await self.write_event(AudioStop().event())
@@ -114,6 +120,45 @@ class GladosEventHandler(AsyncEventHandler):
             )
             raise err
 
+    async def _write_audio(
+        self, pcm: bytes, rate: int, width: int, channels: int
+    ) -> int:
+        """Write one PCM buffer to the client in transport-sized chunks."""
+        if not self.audio_started:
+            await self.write_event(
+                AudioStart(rate=rate, width=width, channels=channels).event()
+            )
+            self.audio_started = True
+
+        samples_per_chunk = max(
+            1,
+            int(getattr(self.cli_args, "samples_per_chunk", 1024)),
+        )
+
+        # Keep sentence-level synthesis quality, but stream PCM in transport-sized chunks.
+        chunks_sent = 0
+        bytes_per_chunk = max(1, width * channels * samples_per_chunk)
+        for offset in range(0, len(pcm), bytes_per_chunk):
+            await self.write_event(
+                AudioChunk(
+                    audio=pcm[offset : offset + bytes_per_chunk],
+                    rate=rate,
+                    width=width,
+                    channels=channels,
+                ).event()
+            )
+            chunks_sent += 1
+        return chunks_sent
+
+    async def _report_tts_error(self, err: Exception) -> None:
+        """Send an Error event and reset the audio stream state."""
+        _LOGGER.error("Error during TTS processing: %s", err)
+        await self.write_event(Error(text=str(err), code="TTSProcessingError").event())
+        if self.audio_started:
+            await self.write_event(AudioStop().event())
+            self.audio_started = False
+            _LOGGER.debug("Audio stream reset after synthesis error.")
+
     async def _handle_synthesize(
         self, synthesize: Synthesize, send_stop: bool = True
     ) -> bool:
@@ -121,10 +166,6 @@ class GladosEventHandler(AsyncEventHandler):
 
         glados_proc = await self.process_manager.get_process()
         total_chunks_sent = 0
-        samples_per_chunk = max(
-            1,
-            int(getattr(self.cli_args, "samples_per_chunk", 1024)),
-        )
 
         try:
             # Start processing with run_tts
@@ -135,26 +176,7 @@ class GladosEventHandler(AsyncEventHandler):
                 if pcm is None:
                     continue
 
-                # Send AudioStart event if it's not already sent
-
-                if not self.audio_started:
-                    await self.write_event(
-                        AudioStart(rate=rate, width=width, channels=channels).event()
-                    )
-                    self.audio_started = True
-
-                # Keep sentence-level synthesis quality, but stream PCM in transport-sized chunks.
-                bytes_per_chunk = max(1, width * channels * samples_per_chunk)
-                for offset in range(0, len(pcm), bytes_per_chunk):
-                    await self.write_event(
-                        AudioChunk(
-                            audio=pcm[offset : offset + bytes_per_chunk],
-                            rate=rate,
-                            width=width,
-                            channels=channels,
-                        ).event()
-                    )
-                    total_chunks_sent += 1
+                total_chunks_sent += await self._write_audio(pcm, rate, width, channels)
 
             _LOGGER.debug(
                 "Sent %s AudioChunk events for chunk: %s",
@@ -162,14 +184,7 @@ class GladosEventHandler(AsyncEventHandler):
                 synthesize.text,
             )
         except Exception as e:
-            _LOGGER.error("Error during TTS processing: %s", e)
-            await self.write_event(
-                Error(text=str(e), code="TTSProcessingError").event()
-            )
-            if self.audio_started:
-                await self.write_event(AudioStop().event())
-                self.audio_started = False
-                _LOGGER.debug("Audio stream reset after synthesis error.")
+            await self._report_tts_error(e)
 
         if send_stop:
             await self.write_event(AudioStop().event())
@@ -178,3 +193,92 @@ class GladosEventHandler(AsyncEventHandler):
 
         _LOGGER.debug("Completed request")
         return True
+
+    # ------------------------------------------------------------------
+    # Streaming pipeline: synthesize the next sentence while the previous
+    # sentence's audio is still being written to the client.
+    # ------------------------------------------------------------------
+
+    async def _start_pipeline(self) -> None:
+        """(Re)start the sentence pipeline for a new text stream."""
+        await self._cancel_pipeline()
+        # maxsize=1 bounds prefetch: one sentence draining to the client plus
+        # one synthesizing ahead, so a flood of input text can't pile up
+        # unbounded synthesis tasks.
+        self._sentence_queue = asyncio.Queue(maxsize=1)
+        self._drain_task = asyncio.create_task(self._drain_audio())
+
+    async def _enqueue_sentence(self, text: str) -> None:
+        """Start synthesis of one sentence and queue its audio for draining."""
+        assert self._sentence_queue is not None
+        pcm_queue: asyncio.Queue[Any] = asyncio.Queue()
+        pump_task = asyncio.create_task(self._pump_sentence(text, pcm_queue))
+        await self._sentence_queue.put((pcm_queue, pump_task))
+
+    async def _pump_sentence(self, text: str, pcm_queue: asyncio.Queue[Any]) -> None:
+        """Synthesize one sentence, pushing PCM chunks into pcm_queue.
+
+        The queue is terminated with None on success or the exception itself
+        on failure, so the drain task never blocks forever.
+        """
+        try:
+            glados_proc = await self.process_manager.get_process()
+            async for chunk in glados_proc.run_tts(text):
+                await pcm_queue.put(chunk)
+            await pcm_queue.put(None)
+        except Exception as err:
+            await pcm_queue.put(err)
+
+    async def _drain_audio(self) -> None:
+        """Write synthesized audio to the client in sentence order."""
+        assert self._sentence_queue is not None
+        while True:
+            item = await self._sentence_queue.get()
+            if item is None:
+                # End of stream
+                return
+            pcm_queue, pump_task = item
+            try:
+                while True:
+                    chunk = await pcm_queue.get()
+                    if chunk is None:
+                        break
+                    if isinstance(chunk, Exception):
+                        raise chunk
+                    pcm, rate, width, channels = chunk
+                    if pcm is None:
+                        continue
+                    await self._write_audio(pcm, rate, width, channels)
+                await pump_task
+            except Exception as err:
+                # Report the failed sentence but keep the stream alive for
+                # the sentences that follow.
+                await self._report_tts_error(err)
+
+    async def _finish_pipeline(self) -> None:
+        """Signal end-of-stream and wait for all queued audio to be written."""
+        if self._sentence_queue is None or self._drain_task is None:
+            return
+        await self._sentence_queue.put(None)
+        try:
+            await self._drain_task
+        finally:
+            self._drain_task = None
+            self._sentence_queue = None
+
+    async def _cancel_pipeline(self) -> None:
+        """Drop any in-flight pipeline work without writing further audio."""
+        if self._drain_task is not None:
+            self._drain_task.cancel()
+            try:
+                await self._drain_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+            self._drain_task = None
+        self._sentence_queue = None
+
+    async def disconnect(self) -> None:
+        """Cancel in-flight synthesis when the client goes away."""
+        await self._cancel_pipeline()

--- a/server/handler.py
+++ b/server/handler.py
@@ -273,6 +273,7 @@ class GladosEventHandler(AsyncEventHandler):
             try:
                 await self._drain_task
             except asyncio.CancelledError:
+                # Expected when awaiting a task that we explicitly cancelled.
                 pass
             except Exception:
                 pass

--- a/server/process.py
+++ b/server/process.py
@@ -10,6 +10,16 @@ from gladostts.glados import TTSRunner  # Import your TTSRunner from glados.py
 
 _LOGGER = logging.getLogger(__name__)
 
+# Audio format produced by the GLaDOS vocoder (22050 Hz, 16-bit mono).
+
+SAMPLE_RATE = 22050
+SAMPLE_WIDTH = 2
+CHANNELS = 1
+
+# Sentinel marking the end of a PCM stream.
+
+_stream_end = object()
+
 
 class GladosProcess:
     """Info for a running GLaDOS process (one TTS instance)."""
@@ -26,18 +36,35 @@ class GladosProcess:
     async def run_tts(
         self, text: str, alpha: float = 1.0
     ) -> AsyncGenerator[tuple[bytes | None, int, int, int], None]:
-        """Process the text and handle TTS output."""
+        """Process the text, yielding PCM chunks as the model produces them.
+
+        Inference runs in a worker thread so the event loop stays responsive;
+        each PCM chunk is forwarded here as soon as the vocoder emits it, so
+        playback can start before the utterance is fully synthesized.
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+
+        def produce() -> None:
+            stream = self.runner.run_tts_stream(text, alpha)
+            try:
+                for pcm in stream:
+                    loop.call_soon_threadsafe(queue.put_nowait, pcm)
+            finally:
+                close = getattr(stream, "close", None)
+                if close is not None:
+                    close()
+
         try:
-            # Offload synchronous model inference so concurrent clients don't block the loop.
-            audio_segment: Any = await asyncio.to_thread(
-                self.runner.run_tts, text, alpha
-            )
-            yield (
-                audio_segment.raw_data,
-                audio_segment.frame_rate,
-                audio_segment.sample_width,
-                audio_segment.channels,
-            )
+            future = loop.run_in_executor(None, produce)
+            future.add_done_callback(lambda _: queue.put_nowait(_stream_end))
+            while True:
+                item = await queue.get()
+                if item is _stream_end:
+                    break
+                yield (item, SAMPLE_RATE, SAMPLE_WIDTH, CHANNELS)
+            # Surface any inference error raised in the worker thread.
+            await future
         except Exception as e:
             _LOGGER.error(
                 "TTS processing failed for text: %s... Error: %s", text[:50], e

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -84,8 +84,8 @@ def test_ensure_model_exists_downloads_missing_files(tmp_path):
 
         ensure_model_exists(tmp_path, base_url)
 
-        assert urlopen_mock.call_count == 6
-        assert copy_mock.call_count == 6
+        assert urlopen_mock.call_count == 5
+        assert copy_mock.call_count == 5
 
 
 # ================================================================
@@ -96,7 +96,6 @@ def test_ensure_model_exists_skips_valid_files(tmp_path):
 
     model_paths = [
         tmp_path / "glados-new.pt",
-        tmp_path / "tacotron-trt.ts",
         tmp_path / "en_us_cmudict_ipa_forward.pt",
         tmp_path / "emb/glados_p2.pt",
         tmp_path / "vocoder-gpu.pt",

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -219,6 +219,9 @@ class TestStreamingEvents:
         assert synthesize_state is not None
         assert synthesize_state.text == ""
 
+        # Clean up the background pipeline task.
+        await handler.disconnect()
+
     @pytest.mark.asyncio
     async def test_synthesize_chunk_event(self, handler):
         """Test SynthesizeChunk event with complete sentence."""
@@ -236,8 +239,13 @@ class TestStreamingEvents:
         result = await handler.handle_event(event)
 
         assert result is True
-        # In streaming mode, chunk handling keeps the audio stream open.
-        assert handler.write_event.call_count >= 2  # AudioStart, AudioChunk
+
+        # Audio is written by the background pipeline; SynthesizeStop flushes it.
+        await handler.handle_event(SynthesizeStop().event())
+
+        event_types = [call[0][0].type for call in handler.write_event.call_args_list]
+        assert "audio-start" in event_types
+        assert "audio-chunk" in event_types
 
     @pytest.mark.asyncio
     async def test_synthesize_chunk_event_with_long_clause(self, handler):
@@ -254,7 +262,12 @@ class TestStreamingEvents:
         result = await handler.handle_event(stream_chunk.event())
 
         assert result is True
-        assert handler.write_event.call_count >= 2
+
+        await handler.handle_event(SynthesizeStop().event())
+
+        event_types = [call[0][0].type for call in handler.write_event.call_args_list]
+        assert "audio-start" in event_types
+        assert "audio-chunk" in event_types
 
     @pytest.mark.asyncio
     async def test_synthesize_chunk_incomplete_sentence(self, handler):
@@ -275,6 +288,9 @@ class TestStreamingEvents:
         assert result is True
         # Should not have sent audio (no complete sentence)
         handler.write_event.assert_not_called()
+
+        # Clean up the background pipeline task.
+        await handler.disconnect()
 
     @pytest.mark.asyncio
     async def test_synthesize_stop_event_with_text(self, handler):
@@ -332,6 +348,107 @@ class TestStreamingEvents:
 
         assert result is True
         assert handler.is_streaming is None  # Should not have changed
+
+
+class TestStreamingPipeline:
+    """Test the sentence pipelining behavior of streaming mode."""
+
+    @pytest.mark.asyncio
+    async def test_sentences_stream_in_order(self, handler):
+        """Audio for multiple sentences must be written in sentence order."""
+        synthesized: list[str] = []
+
+        def make_run_tts(text, *_args, **_kwargs):
+            async def gen():
+                synthesized.append(text)
+                yield f"pcm:{text}".encode(), 22050, 2, 1
+
+            return gen()
+
+        mock_process = MagicMock(spec=GladosProcess)
+        mock_process.run_tts = make_run_tts
+        handler.process_manager.get_process = AsyncMock(return_value=mock_process)
+
+        await handler.handle_event(SynthesizeStart(voice=None).event())
+        await handler.handle_event(
+            SynthesizeChunk(text="First sentence. Second sentence. Trailing").event()
+        )
+        await handler.handle_event(SynthesizeStop().event())
+
+        assert synthesized == [
+            "First sentence.",
+            "Second sentence.",
+            "Trailing",
+        ]
+
+        audio_chunks = [
+            call[0][0].payload
+            for call in handler.write_event.call_args_list
+            if call[0][0].type == "audio-chunk"
+        ]
+        assert audio_chunks == [
+            b"pcm:First sentence.",
+            b"pcm:Second sentence.",
+            b"pcm:Trailing",
+        ]
+
+        # Stream must terminate cleanly: AudioStop before SynthesizeStopped.
+        event_types = [call[0][0].type for call in handler.write_event.call_args_list]
+        assert event_types[-2:] == ["audio-stop", "synthesize-stopped"]
+
+    @pytest.mark.asyncio
+    async def test_sentence_error_keeps_stream_alive(self, handler):
+        """A failing sentence sends Error but later sentences still play."""
+
+        def make_run_tts(text, *_args, **_kwargs):
+            async def gen():
+                if "bad" in text:
+                    raise RuntimeError("TTS failed")
+                yield f"pcm:{text}".encode(), 22050, 2, 1
+
+            return gen()
+
+        mock_process = MagicMock(spec=GladosProcess)
+        mock_process.run_tts = make_run_tts
+        handler.process_manager.get_process = AsyncMock(return_value=mock_process)
+
+        await handler.handle_event(SynthesizeStart(voice=None).event())
+        await handler.handle_event(
+            SynthesizeChunk(text="This one is bad. This one is fine. Next").event()
+        )
+        await handler.handle_event(SynthesizeStop().event())
+
+        event_types = [call[0][0].type for call in handler.write_event.call_args_list]
+        assert "error" in event_types
+        assert "audio-chunk" in event_types
+        assert event_types[-1] == "synthesize-stopped"
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_pipeline(self, handler):
+        """Disconnecting mid-stream cancels the drain task."""
+        await handler.handle_event(SynthesizeStart(voice=None).event())
+        drain_task = _private_attr(handler, "_drain_task")
+        assert drain_task is not None
+
+        await handler.disconnect()
+
+        assert drain_task.done()
+        assert _private_attr(handler, "_drain_task") is None
+        assert _private_attr(handler, "_sentence_queue") is None
+
+    @pytest.mark.asyncio
+    async def test_restart_stream_resets_pipeline(self, handler):
+        """A second SynthesizeStart replaces the previous pipeline."""
+        await handler.handle_event(SynthesizeStart(voice=None).event())
+        first_drain = _private_attr(handler, "_drain_task")
+
+        await handler.handle_event(SynthesizeStart(voice=None).event())
+        second_drain = _private_attr(handler, "_drain_task")
+
+        assert first_drain is not second_drain
+        assert first_drain.done()
+
+        await handler.disconnect()
 
 
 class TestHandleSynthesize:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -35,14 +35,8 @@ class TestGladosProcessLogic:
         """Test normal TTS flow."""
         mock_runner = MagicMock()
 
-        mock_audio = MagicMock()
-        mock_audio.raw_data = b"audio_data"
-        mock_audio.frame_rate = 22050
-        mock_audio.sample_width = 2
-        mock_audio.channels = 1
-
-        run_tts_mock = MagicMock(return_value=mock_audio)
-        mock_runner.run_tts = run_tts_mock
+        run_tts_stream_mock = MagicMock(return_value=iter([b"audio_data"]))
+        mock_runner.run_tts_stream = run_tts_stream_mock
 
         p = GladosProcess("default", mock_runner)
 
@@ -51,12 +45,28 @@ class TestGladosProcessLogic:
             results.append(chunk)
 
         assert len(results) == 1
-        raw, rate, _, _ = results[0]
+        raw, rate, width, channels = results[0]
         assert raw == b"audio_data"
         assert rate == 22050
-        assert run_tts_mock.call_count == 1
-        assert run_tts_mock.call_args is not None
-        assert run_tts_mock.call_args.args == ("Test text", 1.0)
+        assert width == 2
+        assert channels == 1
+        assert run_tts_stream_mock.call_count == 1
+        assert run_tts_stream_mock.call_args is not None
+        assert run_tts_stream_mock.call_args.args == ("Test text", 1.0)
+
+    @pytest.mark.asyncio
+    async def test_tts_streams_multiple_chunks(self):
+        """PCM chunks are forwarded individually as the model produces them."""
+        mock_runner = MagicMock()
+        mock_runner.run_tts_stream = MagicMock(
+            return_value=iter([b"chunk1", b"chunk2", b"chunk3"])
+        )
+
+        p = GladosProcess("default", mock_runner)
+
+        results = [chunk async for chunk, _, _, _ in p.run_tts("Test text")]
+
+        assert results == [b"chunk1", b"chunk2", b"chunk3"]
 
     @pytest.mark.asyncio
     async def test_async_generator_pattern(self):
@@ -78,13 +88,33 @@ class TestGladosProcessLogic:
     async def test_run_tts_exception_path(self):
         """Ensure exception inside run_tts is yielded and re-raised."""
         mock_runner = MagicMock()
-        mock_runner.run_tts.side_effect = RuntimeError("boom")
+        mock_runner.run_tts_stream.side_effect = RuntimeError("boom")
 
         p = GladosProcess("voice", mock_runner)
 
         with pytest.raises(RuntimeError):
             async for _ in p.run_tts("text"):
                 pass
+
+    @pytest.mark.asyncio
+    async def test_run_tts_exception_midstream(self):
+        """An exception after some chunks still yields the earlier chunks."""
+
+        def stream(*_args, **_kwargs):
+            yield b"chunk1"
+            raise RuntimeError("boom")
+
+        mock_runner = MagicMock()
+        mock_runner.run_tts_stream = stream
+
+        p = GladosProcess("voice", mock_runner)
+
+        results = []
+        with pytest.raises(RuntimeError):
+            async for chunk, _, _, _ in p.run_tts("text"):
+                results.append(chunk)
+
+        assert results == [b"chunk1"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reduces perceived latency end-to-end: PCM now streams to the client as the vocoder produces it, and in streaming mode the next sentence is synthesized while the previous sentence's audio is still being written out. Depends on the companion gladostts PR (Jonah-May-OSS/glados-tts#72) which adds `TTSRunner.run_tts_stream()`; the submodule pointer in this PR references that branch commit and should be bumped to the merge commit once the gladostts PR lands.

### Streaming transport (`server/process.py`)

`GladosProcess.run_tts` no longer waits for the full utterance. Inference runs in a worker thread (as before), but each PCM chunk is forwarded to the event loop via a queue as soon as the vocoder emits it. For long utterances the client starts receiving audio after the first vocoder window instead of after the whole clip.

### Sentence pipelining (`server/handler.py`)

In streaming mode (`SynthesizeStart`/`Chunk`/`Stop`), sentence synthesis and audio transmission previously alternated: the GPU idled while audio was written to the client, and the network idled during synthesis. Now:

- Each detected sentence is synthesized by a pump task feeding a per-sentence PCM queue; a single drain task writes audio to the client strictly in sentence order.
- Prefetch is bounded (one sentence synthesizing ahead of the one draining), so a flood of input text cannot pile up unbounded synthesis tasks.
- A failing sentence sends an `Error` event and resets the audio stream, but later sentences still play (previously matching behavior, now per-sentence).
- `disconnect()` cancels in-flight pipeline work when the client goes away.
- `SynthesizeStop` flushes the pipeline before `AudioStop`/`SynthesizeStopped`, so protocol ordering is unchanged.

The non-streaming `Synthesize` path is unchanged structurally but now also benefits from chunked PCM delivery.

### Submodule bump (`gladostts`)

Inference hot-path cleanups (no more per-request `empty_cache`/`synchronize`/RNN re-flatten), warm-up/inference dtype consistency (fixes first-request TRT re-specialization), lazy base-model loading when TRT engines are cached (lower startup time and peak VRAM), an inference lock (TRT execution contexts are not thread-safe across `asyncio.to_thread` workers), and windowed vocoding behind the new `run_tts_stream()`. See the gladostts PR for details.

## Testing

- 71/71 tests pass, including new coverage: sentence-order guarantees under pipelining, per-sentence error resilience, disconnect cancellation, pipeline restart on a second `SynthesizeStart`, and multi-chunk PCM forwarding.
- `ruff check`, `ruff format --check`, `pylint` (10/10), `pyright` all pass.
- ⚠️ Needs an on-GPU smoke test before merge (no CUDA on the dev machine): end-to-end synthesis through Home Assistant / a Wyoming client, audio quality on a long utterance, and concurrent-client behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
