### PR TITLE
Keep decimals intact when a chunk ends mid-number

### DIFF
--- a/server/sentence_boundary.py
+++ b/server/sentence_boundary.py
@@ -91,11 +91,17 @@ class SentenceBoundaryDetector:
 
     @staticmethod
     def _is_decimal(candidate: str, trailing: str) -> bool:
+        """A digit before the period means a decimal, or that we cannot tell yet.
+
+        While streaming, the fractional digits may not have arrived; treat a
+        trailing "3." as a decimal so the segment stays buffered until the next
+        chunk decides it.
+        """
         stripped_candidate = candidate.rstrip()
-        return bool(
-            re.search(r"\d\.$", stripped_candidate)
-            and re.match(r"\d", trailing.lstrip())
-        )
+        if not re.search(r"\d\.$", stripped_candidate):
+            return False
+        rest = trailing.lstrip()
+        return not rest or bool(re.match(r"\d", rest))
 
 
 def remove_asterisks(text: str) -> str:

--- a/tests/test_sentence_boundary.py
+++ b/tests/test_sentence_boundary.py
@@ -138,3 +138,22 @@ class TestSentenceBoundaryDetector:
             "Pi is 3.14 and rising."
         ]
         assert d.finish() == ""
+
+    def test_decimal_split_across_chunks_does_not_split(self):
+        d = SentenceBoundaryDetector()
+
+        assert not list(d.add_chunk("Your reaction time was 0."))
+        assert list(d.add_chunk("4 seconds slower. ")) == [
+            "Your reaction time was 0.4 seconds slower."
+        ]
+        assert d.finish() == ""
+
+    def test_sentence_ending_in_digit_flushes_on_next_chunk(self):
+        d = SentenceBoundaryDetector()
+
+        assert not list(d.add_chunk("It landed in 1969."))
+        assert list(d.add_chunk(" Then we left.")) == [
+            "It landed in 1969.",
+            "Then we left.",
+        ]
+        assert d.finish() == ""


### PR DESCRIPTION
_is_decimal required a digit after the period, so a streamed chunk ending in "0." was treated as a sentence end. The period was consumed as a terminator instead of reaching normalize_numbers, and "0.4" was spoken as "zero" pause "four".

Treat a digit-preceded period at the end of the buffer as undecidable and hold the segment until the next chunk resolves it. A sentence that genuinely ends in a digit now flushes one chunk later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sentence detection for decimal numbers split across streamed text chunks.
  * Correctly handles sentences ending in digits and flushes buffered content at the appropriate time.

* **Tests**
  * Added coverage for decimal values and digit-ending sentences across chunk boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->