### PR TITLE
ci: drop redundant driver/docker/CUDA installs on self-hosted runner

### DIFF
--- a/.github/workflows/publish_container.yaml
+++ b/.github/workflows/publish_container.yaml
@@ -29,53 +29,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-      - name: Install Nvidia Drivers
-        shell: bash
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y nvidia-open
-      
-      - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76
-        with:
-          use-github-cache: false
-
-      - name: Install Docker and Buildx
-        shell: bash
-        run: |
-          # Add Docker's official GPG key:
-          sudo apt-get update
-          sudo apt-get install ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
+      # GPU driver (nvidia runtime) and Docker (dind sidecar) come from the
+      # self-hosted ARC runner; building the image doesn't need host CUDA/nvcc.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@f4e8deed0c3c26542279f4042c0e1d059cbf012d
         with:
           platforms: all
-
-      - name: Install Nvidia Container Toolkit
-        shell: bash
-        run: |
-          curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-          && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
-            sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-            sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-          sudo apt-get update
-          sudo apt-get install -y nvidia-container-toolkit
-          sudo nvidia-ctk runtime configure --runtime=docker
-          sudo systemctl restart docker
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@21162887f0d6e25b4e8eafb0cf44cf9bf7f6acd3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,27 +64,23 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install GCC and G++
-        run: |
-          sudo apt update
-          sudo apt install -y gcc g++
+      # gcc/g++, netcat-openbsd and virtualenv are baked into the custom runner
+      # image (local/gpu-runner), so no in-job apt/pip installs are needed.
 
-      - name: Install Netcat
-        run: sudo apt-get install -y netcat-openbsd
-
+      # RUNNER_TOOL_CACHE points at the persistent NFS cache, so 3.13 is
+      # downloaded once and restored instantly after.
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
-      - name: Install Python Virtual Environment Package
-        run: pip install virtualenv
-
-      # GPU driver is provided by the self-hosted runner's nvidia runtime; cache the toolkit.
+      # GPU driver comes from the runner's nvidia runtime; the toolkit installer
+      # is cached in both GitHub cache and the persistent runner tool cache.
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.35
         with:
           use-github-cache: true
+          use-local-cache: true
       
       - name: Setup Virtual Environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,16 +82,32 @@ jobs:
           use-github-cache: true
           use-local-cache: true
       
+      # The server defaults --models-dir to $MODELS_DIR (falling back to the
+      # container path /usr/src/models, which isn't writable on a self-hosted
+      # runner). Point it at the persistent NFS cache when available so the
+      # model download is reused across runs; otherwise a writable local dir.
+      - name: Configure models dir
+        run: |
+          if [ -n "$RUNNER_CACHE" ]; then
+            MODELS_DIR="$RUNNER_CACHE/glados/models"
+          else
+            MODELS_DIR="$PWD/gladostts/models"
+          fi
+          mkdir -p "$MODELS_DIR"
+          echo "MODELS_DIR=$MODELS_DIR" >> "$GITHUB_ENV"
+          echo "Using MODELS_DIR=$MODELS_DIR"
+
       - name: Setup Virtual Environment
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          python3 download.py
+          python3 download.py --model-dir "$MODELS_DIR"
           pip install -r requirements.txt
 
       - name: Start GLaDOS TTS Server and Test Listening
         run: |
           source .venv/bin/activate
+          # __main__.py reads MODELS_DIR from the environment for --models-dir.
           nohup python3 __main__.py --uri 'tcp://0.0.0.0:10201' --debug --streaming > server.log 2>&1 &
           SERVER_PID=$!
           echo "Started GLaDOS TTS server with PID $SERVER_PID"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,17 +80,11 @@ jobs:
       - name: Install Python Virtual Environment Package
         run: pip install virtualenv
 
-      - name: Install Nvidia Drivers
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y nvidia-open
-
+      # GPU driver is provided by the self-hosted runner's nvidia runtime; cache the toolkit.
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.35
         with:
-          use-github-cache: false
+          use-github-cache: true
       
       - name: Setup Virtual Environment
         run: |
@@ -146,16 +140,3 @@ jobs:
         with:
           name: server-logs
           path: server.log
-
-      - name: CUDA Driver/Library Mismatch Auto-Fix
-        if: ${{ failure() }}
-        run: |
-          echo "Scanning server.log for NVML initialization failure..."
-          if grep -Fq "Failed to initialize NVML: Driver/library version mismatch" server.log; then
-            echo "CUDA driver/library mismatch detected—upgrading system and rebooting."
-            sudo apt update
-            sudo apt upgrade -y
-            sudo reboot
-          else
-            echo "No NVML mismatch found; skipping auto-fix."
-          fi


### PR DESCRIPTION
Mirror of wyoming-whisper-trt#982. The self-hosted ARC runner provides the GPU driver (nvidia runtime) + Docker (dind sidecar); removes redundant per-run installs and the in-container 'systemctl restart docker' / 'sudo reboot' steps (which would kill the runner pod). CUDA toolkit kept + cached.