### PR TITLE
build: make apt resilient to stalled mirror fetches (retries + timeout)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,11 @@ WORKDIR /usr/src
 # NOTE: clones the ORG repo (was JonahMMay, a stale personal fork). `--copies`
 # makes the venv relocatable onto the slim runtime below. download.py places
 # models in gladostts/models (its default), which the runtime reads.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Make apt resilient to a stalled mirror connection: without a timeout apt can
+# hang indefinitely on a half-open fetch (observed wedging a multi-hour build);
+# retries + a 30s timeout make it fail fast and recover instead.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99network-resilience \
+    && apt-get update && apt-get install -y --no-install-recommends \
         curl \
         python3 \
         python3-pip \
@@ -40,7 +44,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ===========================================================================
 FROM ubuntu:24.04 AS runtime
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99network-resilience \
+    && apt-get update && apt-get install -y --no-install-recommends \
         python3 \
         python3.12 \
         ffmpeg \

--- a/docker/Dockerfile.igpu
+++ b/docker/Dockerfile.igpu
@@ -2,7 +2,8 @@ FROM nvcr.io/nvidia/tensorrt:26.02-py3-igpu
 
 WORKDIR /usr/src
 
-RUN apt-get update && \
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99network-resilience && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         python3 \


### PR DESCRIPTION
Preventatively applies the same fix diagnosed on `wyoming-whisper-trt` (Jonah-May-OSS/wyoming-whisper-trt#1002): a transient mirror stall can leave `apt-get` wedged on a half-open connection with no timeout, hanging the multi-arch build for hours (BuildKit waits on apt indefinitely).

Adds an apt.conf drop-in to every apt step — `docker/Dockerfile` (builder + runtime) and `docker/Dockerfile.igpu`:
```
Acquire::Retries "3";
Acquire::http::Timeout "30";
Acquire::https::Timeout "30";
```
So a stalled fetch fails in 30s and retries instead of hanging indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)