### PR TITLE
perf(image): multi-stage slim build for iGPU (mirror dGPU #606) [needs Jetson validation]

### DIFF
--- a/docker/Dockerfile.igpu
+++ b/docker/Dockerfile.igpu
@@ -1,28 +1,72 @@
-FROM nvcr.io/nvidia/tensorrt:26.02-py3-igpu
+# syntax=docker/dockerfile:1
+
+# ===========================================================================
+# Builder: full NGC TensorRT iGPU image (arm64). Clones the source, builds the
+# venv (torch + torch-tensorrt + deps) and downloads the TTS models. Exactly as
+# with the dGPU image (docker/Dockerfile), the CUDA devel toolkit and build
+# toolchain here are build-only and are NOT carried into the runtime image —
+# the venv is self-contained (torch bundles its CUDA/cuDNN wheels, and
+# tensorrt/torch-tensorrt are wheels).
+#
+# `--copies` makes the venv relocatable onto the slim runtime below. Clones the
+# ORG repo (was JonahMMay, a stale personal fork). download.py places models in
+# gladostts/models (its default), which run.sh reads.
+#
+# VALIDATION NOTE: the venv-relocation trick assumes (a) this NGC iGPU base is
+# Ubuntu 24.04 / python3.12, so the runtime base below matches its glibc +
+# python, and (b) the aarch64 torch / torch-tensorrt wheels are self-contained
+# w.r.t. CUDA (like their x86 counterparts). Both hold for the dGPU image on
+# x86 but MUST be confirmed on Jetson hardware before release — see the iGPU
+# validation checklist in the PR.
+# ===========================================================================
+FROM nvcr.io/nvidia/tensorrt:26.02-py3-igpu AS builder
 
 WORKDIR /usr/src
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         python3 \
         python3-pip \
         python3-venv \
-        git && \
-    rm -rf /var/lib/apt/lists/* && \
-    git clone --recurse-submodules https://github.com/JonahMMay/wyoming-glados && \
-    cd wyoming-glados && \
-    python3 -m venv venv && \
-    venv/bin/pip install --no-cache-dir -U setuptools wheel && \
-    venv/bin/python download.py && \
-    venv/bin/pip install -r requirements.txt
+        git \
+    && git clone --recurse-submodules https://github.com/Jonah-May-OSS/wyoming-glados \
+    && cd wyoming-glados \
+    && python3 -m venv --copies venv \
+    && venv/bin/pip install --no-cache-dir -U setuptools wheel \
+    && venv/bin/python download.py \
+    && venv/bin/pip install --no-cache-dir -r requirements.txt \
+    && find venv -type d -name __pycache__ -prune -exec rm -rf {} + \
+    && rm -rf .git /root/.cache/pip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Set environment so the venv is used by default:
+# ===========================================================================
+# Runtime: slim Ubuntu (must match the NGC iGPU base's Ubuntu / glibc /
+# python3.12 so the --copies venv relocates cleanly). Adds only the Python
+# stdlib, ffmpeg (pydub audio), libgomp (torch OpenMP) and ca-certificates
+# (TLS trust; plain ubuntu ships no CA bundle). libcuda.so / nvidia-smi are
+# injected by the NVIDIA container runtime. Drops the CUDA devel toolkit +
+# build toolchain that the self-contained venv makes redundant.
+# ===========================================================================
+FROM ubuntu:24.04 AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        python3.12 \
+        ffmpeg \
+        libgomp1 \
+        ca-certificates \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# Use the venv by default.
 ENV VIRTUAL_ENV=/usr/src/wyoming-glados/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-WORKDIR /
+COPY --from=builder /usr/src/wyoming-glados /usr/src/wyoming-glados
 
+WORKDIR /
 COPY ./run.sh ./
 
 EXPOSE 10201


### PR DESCRIPTION
## What
Multi-stage slim build for the **iGPU (Jetson)** image, mirroring the dGPU slimming in #606.

The iGPU `Dockerfile.igpu` was single-stage on `nvcr.io/nvidia/tensorrt:26.02-py3-igpu`, shipping the CUDA devel toolkit + build toolchain in the final image. It is structurally identical to the pre-#606 dGPU build (NGC tensorrt base + `venv` + `requirements.txt`), so the same trick applies:

- **Builder**: NGC iGPU base builds the `--copies` venv + downloads models (unchanged deps).
- **Runtime**: slim `ubuntu:24.04` (arm64) + `ffmpeg` / `libgomp1` / `ca-certificates`, `COPY --from=builder` the app+venv+models.
- Also fixes the clone URL to the org repo (was the stale `JonahMMay` fork) — same fix as #606.

## ⚠️ Draft — needs Jetson hardware validation
The iGPU image never builds in PR CI (build-check is amd64; iGPU only builds via QEMU-arm64 at **release**). The relocation rests on two assumptions verified on x86 (dGPU) but **unconfirmed on arm64/Jetson**:

1. NGC `26.02-py3-igpu` is Ubuntu 24.04 / python3.12 (must match the `ubuntu:24.04` runtime's glibc + python).
2. The aarch64 `torch` / `torch-tensorrt` wheels are self-contained w.r.t. CUDA (don't link the base's `/usr/local/cuda`).

### On-device checklist before un-drafting
- [ ] Confirm base ubuntu/python: `docker run --rm nvcr.io/nvidia/tensorrt:26.02-py3-igpu cat /etc/os-release; python3 -V`
- [ ] Build the image on/for Jetson (`docker buildx build --platform linux/arm64 -f docker/Dockerfile.igpu docker/`)
- [ ] `ldd` the venv's `torch/_C*.so` + `torch_tensorrt` libs in the **runtime** image — no unresolved CUDA/`/usr/local/cuda` refs
- [ ] Server starts on the Jetson: model download over TLS succeeds, vocoder TRT engine compiles, "Server started and listening on :10201"
- [ ] Compare pull size vs the current iGPU image (crictl/ctr compressed, not `docker images`)

If the base isn't 24.04 or the wheels aren't self-contained, fall back to same-base cache cleanup only (no runtime-base swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)